### PR TITLE
Fix bare and unrecognized PayPal links

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -347,11 +347,13 @@
           second.querySelector('.venmo').appendChild(link('https://venmo.com/' + record.venmo.replace('@', ''), record.venmo));
         }
         if(record.paypal) {
-          if(record.paypal.startsWith('https://')) {
+          if(record.paypal.startsWith('https://') || record.paypal.toLowerCase().startsWith('paypal.me/')) {
             third.querySelector('.paypal').appendChild(link(record.paypal, record.paypal));
           } else if (record.paypal.indexOf('@') >= 0) {
             var email_url = 'https://www.paypal.com/myaccount/transfer/homepage/external/summary?recipient=';
             third.querySelector('.paypal').appendChild(link(email_url + record.paypal, record.paypal));
+          } else {
+            third.querySelector('.paypal').innerText = record.paypal;
           }
         }
         dest.appendChild(first);


### PR DESCRIPTION
Some PayPal entries are "bare" links, i.e. not starting with `https://`. This fixes bare links to work, and adds a fallback for unrecognized
links.

Fixes #5