### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -8,8 +8,7 @@ verify_ssl = true
 [packages]
 google-api-python-client = "*"
 jinja2 = "*"
-fuzzywuzzy = "*"
-python-levenshtein = "*"
+rapidfuzz = "*"
 flask = "*"
 boto3 = "*"
 flask-httpauth = "*"

--- a/gainesvilletips_org.py
+++ b/gainesvilletips_org.py
@@ -14,7 +14,7 @@ import boto3
 from botocore.exceptions import ClientError
 from flask import abort, Flask, redirect, render_template, request, url_for
 from flask_httpauth import HTTPBasicAuth
-from fuzzywuzzy import process
+from rapidfuzz import process
 from googleapiclient.discovery import build
 from googleapiclient.http import MediaIoBaseDownload
 from jinja2 import Markup

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,6 @@ decorator==4.4.2
 docutils==0.15.2
 flask-httpauth==3.3.0
 flask==1.1.1
-fuzzywuzzy==0.18.0
 google-api-core==1.16.0
 google-api-python-client==1.8.0
 google-auth-httplib2==0.0.3
@@ -38,8 +37,8 @@ pyasn1-modules==0.2.8
 pyasn1==0.4.8
 pygments==2.6.1
 python-dateutil==2.8.1
-python-levenshtein==0.12.0
 pytz==2019.3
+rapidfuzz==0.7.6
 requests==2.23.0
 rsa==4.0
 s3transfer==0.3.3


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2.
For this reason this Pullrequest replaces FuzzyWuzzy with  [rapidfuzz](https://github.com/maxbachmann/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed.
Rapidfuzz is:
- Mit licensed so it can be used with the license used by this project
- Is faster than FuzzyWuzzy

It is still required to update the Pipfile.lock